### PR TITLE
fix broken star history chart

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -104,4 +104,4 @@ Thanks to the [Burlesco](https://github.com/burlesco/burlesco) and [Hover](https
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=manualdousuario/marreta&type=Date)](https://star-history.com/#manualdousuario/marreta&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=manualdousuario/marreta&type=Date)](https://star-history.dera.page/#manualdousuario/marreta&Date)

--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ Agradecimento ao projeto [Burlesco](https://github.com/burlesco/burlesco) e [Hov
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=manualdousuario/marreta&type=Date)](https://star-history.com/#manualdousuario/marreta&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=manualdousuario/marreta&type=Date)](https://star-history.dera.page/#manualdousuario/marreta&Date)


### PR DESCRIPTION
The star history chart is currently broken because GitHub restricts access to its stargazer API. This moves it to a working service that needs no API token, so the chart renders again. Kept the badge untouched.